### PR TITLE
Fix intl compatibility of type builtin

### DIFF
--- a/bin/git-stream
+++ b/bin/git-stream
@@ -254,7 +254,7 @@ gitstream_source() {
 
     source ${file}
 
-    command_type=$(type ${func} | head -n 1)
+    command_type=$(LC_ALL=C type ${func} | head -n 1)
 
     if [ "${command_type}" != "${func} is a function" ]; then
         usage; exit 1


### PR DESCRIPTION
Because of

```
garex@home-ustimenko:/tmp/git-stream$ LC_MESSAGES=en_US.UTF-8 type echo
echo is a shell builtin
garex@home-ustimenko:/tmp/git-stream$ LC_MESSAGES=ru_RU.UTF-8 type echo
echo — это встроенная команда bash
garex@home-ustimenko:/tmp/git-stream$ LC_MESSAGES=C type echo
echo is a shell builtin
```

I used LC_ALL just incase. On my bash LC_MESSAGES also works.